### PR TITLE
feat: added getProjectTeamsMembers resolver

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -1,12 +1,13 @@
 import { BaseContext } from '@apollo/server';
-import { PrismaClient } from '@prisma/client';
+import { MemberRole, PrismaClient } from '@prisma/client';
 import { InterfaceAuthData } from './middlewares/isAuth';
 
 export const client = new PrismaClient();
-export type PrismaClientType = PrismaClient; 
+export type PrismaClientType = PrismaClient;
 
-export interface MyContext extends InterfaceAuthData, BaseContext{
+export interface MyContext extends InterfaceAuthData, BaseContext {
   client: PrismaClientType
+  userRole: MemberRole | undefined | null
 }
 
 export type TransactionClient = Parameters<Parameters<PrismaClient['$transaction']>[0]>[0];

--- a/src/directives/directiveTransformers/roleDirectiveTransformer.ts
+++ b/src/directives/directiveTransformers/roleDirectiveTransformer.ts
@@ -25,10 +25,11 @@ export function roleDirectiveTransformer(
           context,
           info
         ): Promise<string> => {
-          let userRole: InterfaceUserRole = { role: undefined };
+
           if (args.projectId || args.input.projectId) {
             try {
-              userRole = await isUserPartOfProject(context.userId, args.projectId, context.client);
+              const projectId = args.projectId || args.input.projectId;
+              const userRole = await isUserPartOfProject(context.userId, projectId, context.client);
               context.userRole = userRole.role;
             }
             catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ async function startServer() {
       context: async ({ req }): Promise<MyContext> => ({
         ...isAuth(req),
         client,
+        userRole: undefined
       })
     })
   );

--- a/src/resolvers/Mutation/addProjectTeam.ts
+++ b/src/resolvers/Mutation/addProjectTeam.ts
@@ -8,20 +8,6 @@ export const addProjectTeam: MutationResolvers["addProjectTeam"] = async (_, arg
         throw new Error("you are not authorized")
     }
 
-    const team = await context.client.team.findFirst({
-        where: {
-            id: input.teamId
-        },
-        select: {
-            id: true,
-            name: true,
-        }
-    });
-
-    if (!team) {
-        throw new Error("Team not exist")
-    }
-
     const project = await context.client.project.findFirst({
         where: {
             AND: [
@@ -40,6 +26,26 @@ export const addProjectTeam: MutationResolvers["addProjectTeam"] = async (_, arg
             },
         }
     });
+
+    if (!project) {
+        throw new Error("Project not found")
+    }
+
+
+
+    const team = await context.client.team.findFirst({
+        where: {
+            id: input.teamId
+        },
+        select: {
+            id: true,
+            name: true,
+        }
+    });
+
+    if (!team) {
+        throw new Error("Team not exist")
+    }
 
     let teamExist: boolean = false;
 
@@ -60,19 +66,6 @@ export const addProjectTeam: MutationResolvers["addProjectTeam"] = async (_, arg
                 data: {
                     teamId: input.teamId,
                     projectId: input.projectId
-                }
-            });
-
-            await prisma.project.update({
-                where: {
-                    id: input.projectId
-                },
-                data: {
-                    teams: {
-                        connect: {
-                            id: input.teamId
-                        }
-                    }
                 }
             });
         })

--- a/src/resolvers/Mutation/assignIssue.ts
+++ b/src/resolvers/Mutation/assignIssue.ts
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 import { MutationResolvers } from '../../types/generatedGraphQLTypes';
 import { IssueType, MemberRole, Project, User } from '@prisma/client';
-import { PrismaClientType, TransactionClient } from '../../db';
+import { TransactionClient } from '../../db';
 import { notFoundError } from '../../libraries/errors/notFoundError';
 import { conflictError } from '../../libraries/errors/conflictError';
-import { UNAUTHORIZED_USER, ISSUE_NOT_FOUND, ALREADY_ASSIGNED_ISSUE, ASSIGNEE_NOT_MEMBER, ASSIGNEE_NOT_CONTRIBUTOR, PROJECT_NOT_FOUND, ASSIGNEE_NOT_FOUND, INVALID_ISSUE_TYPE } from '../../globals';
+import {  ISSUE_NOT_FOUND, ALREADY_ASSIGNED_ISSUE, ASSIGNEE_NOT_MEMBER, ASSIGNEE_NOT_CONTRIBUTOR, PROJECT_NOT_FOUND, ASSIGNEE_NOT_FOUND, INVALID_ISSUE_TYPE } from '../../globals';
 
 export const assineIssue: MutationResolvers['assineIssue'] = async (
   _,

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -18,6 +18,7 @@ import { removeTeamMember } from './removeTeamMember';
 import { refreshToken } from './refreshToken';
 import { addIssueInSprint } from './addIssueInSprint';
 import { removeTeam } from './removeTeam';
+import { addProjectTeam } from './addProjectTeam';
 
 export const Mutation: MutationResolvers = {
   signup,
@@ -40,4 +41,5 @@ export const Mutation: MutationResolvers = {
 
   refreshToken,
   addIssueInSprint,
+  addProjectTeam,
 };

--- a/src/resolvers/Query/allSprints.ts
+++ b/src/resolvers/Query/allSprints.ts
@@ -12,6 +12,7 @@ export const isUserPartOfProject = async (
   client: PrismaClientType
 ): Promise<InterfaceUserRole> => {
 
+
   const userTeam = await client.userTeam.findFirst({
     where: {
       AND: [
@@ -37,7 +38,8 @@ export const isUserPartOfProject = async (
       },
     },
   });
-  if (!userTeam || userTeam.role) {
+
+  if (!userTeam || !userTeam.role) {
     return { role: undefined }
   }
 

--- a/src/resolvers/Query/getProjectTeamsMembers.ts
+++ b/src/resolvers/Query/getProjectTeamsMembers.ts
@@ -1,0 +1,42 @@
+import { QueryResolvers } from "../../types/generatedGraphQLTypes";
+
+export const getProjectTeamsMembers: QueryResolvers["getProjectTeamsMembers"] = async (_, args, context) => {
+
+    if (!context.userRole) {
+        throw new Error("unauthorized access")
+    }
+
+    const teams = await context.client.team.findMany({
+        where: {
+            projects: {
+                some: {
+                    projectId: args.projectId
+                }
+            }
+        },
+        include: {
+            users: {
+                select: {
+                    user: {
+                        select: {
+                            id: true,
+                            email: true,
+                            username: true,
+                        }
+                    },
+                    id: true,
+                    role: true,
+                    joinedAt: true
+                }
+            }
+        }
+    });
+
+    if (teams.length <= 0) {
+        throw new Error("Teams not found")
+    }
+
+    return teams;
+
+
+}

--- a/src/resolvers/Query/getTeam.ts
+++ b/src/resolvers/Query/getTeam.ts
@@ -19,6 +19,7 @@ export const getTeamById: QueryResolvers['getTeamById'] = async (
               email: true,
               profile: {
                 select: {
+                  id: true,
                   avatar: true,
                   firstName: true,
                   lastName: true
@@ -41,16 +42,8 @@ export const getTeamById: QueryResolvers['getTeamById'] = async (
     throw new Error("You are Not Authorized Person")
   }
 
-  const members = team.users.map((user) => {
-    return {
-      id: user.user.id,
-      username: user.user.username,
-      email: user.user.email
-    }
-  });
 
   return {
-    ...team,
-    members
+    ...team
   }
 };

--- a/src/resolvers/Query/index.ts
+++ b/src/resolvers/Query/index.ts
@@ -10,6 +10,7 @@ import { healthCheck } from './healthCheck';
 import { getRecentProject } from './getRecentProject';
 import { getUserByEmail } from './getUserByEmail';
 import { getAllUserTeams } from './allUserTeams';
+import { getProjectTeamsMembers } from './getProjectTeamsMembers';
 
 export const Query = {
   healthCheck,
@@ -23,5 +24,6 @@ export const Query = {
   getAllProjects,
   getRecentProject,
   getAllUserTeams,
-  getUserByEmail
+  getUserByEmail,
+  getProjectTeamsMembers
 };

--- a/src/typeDef/queries.ts
+++ b/src/typeDef/queries.ts
@@ -4,16 +4,29 @@ export const queries = gql`
   # Queries
   type Query {
     healthCheck: ResponseMessage!
+
     getUserById(userId: ID!): User! @auth
+
     getProjectById(projectId: ID!): Project! @auth
+
     getTeamById(teamId: ID!): Team! @auth
+
     getIssueById(issueId: ID!): Issue! @auth
+
     getSprintById(id: ID!, projectId: ID!): Sprint! @auth
+
     getAllProjects: [Project] @auth
+
     getAllIssues(projectId: ID!): [Issue] @auth
+
     getAllSprints(projectId: ID!): [Sprint]! @auth
+
     getAllUserTeams: [UserTeam]! @auth
+
     getRecentProject: Project @auth
+
     getUserByEmail(email: String!): User!  @auth
+
+    getProjectTeamsMembers(projectId: ID!): [Team]  @auth @role(requires:Contributor)
   }
 `;

--- a/src/typeDef/types.ts
+++ b/src/typeDef/types.ts
@@ -83,8 +83,8 @@ export const types = gql`
 
   type UserTeam {
     id: ID!
-    userId: ID!
-    teamId: ID!
+    userId: ID
+    teamId: ID
     role: MemberRole
     joinedAt: DateTime
     user: User
@@ -96,7 +96,7 @@ export const types = gql`
     id: ID!
     name: String
     creatorId: String
-    members: [User]
+    users: [UserTeam]
     projects: [Project]
     createdAt: DateTime
     updatedAt: DateTime

--- a/src/types/generatedGraphQLTypes.ts
+++ b/src/types/generatedGraphQLTypes.ts
@@ -324,6 +324,7 @@ export type Query = {
   getAllUserTeams: Array<Maybe<UserTeam>>;
   getIssueById: Issue;
   getProjectById: Project;
+  getProjectTeamsMembers?: Maybe<Array<Maybe<Team>>>;
   getRecentProject?: Maybe<Project>;
   getSprintById: Sprint;
   getTeamById: Team;
@@ -349,6 +350,11 @@ export type QueryGetIssueByIdArgs = {
 
 
 export type QueryGetProjectByIdArgs = {
+  projectId: Scalars['ID']['input'];
+};
+
+
+export type QueryGetProjectTeamsMembersArgs = {
   projectId: Scalars['ID']['input'];
 };
 
@@ -425,10 +431,10 @@ export type Team = {
   createdAt?: Maybe<Scalars['DateTime']['output']>;
   creatorId?: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
-  members?: Maybe<Array<Maybe<User>>>;
   name?: Maybe<Scalars['String']['output']>;
   projects?: Maybe<Array<Maybe<Project>>>;
   updatedAt?: Maybe<Scalars['DateTime']['output']>;
+  users?: Maybe<Array<Maybe<UserTeam>>>;
 };
 
 export type UnauthenticatedError = Error & {
@@ -469,9 +475,9 @@ export type UserTeam = {
   joinedAt?: Maybe<Scalars['DateTime']['output']>;
   role?: Maybe<MemberRole>;
   team?: Maybe<Team>;
-  teamId: Scalars['ID']['output'];
+  teamId?: Maybe<Scalars['ID']['output']>;
   user?: Maybe<User>;
-  userId: Scalars['ID']['output'];
+  userId?: Maybe<Scalars['ID']['output']>;
 };
 
 export type AddIssueInput = {
@@ -858,6 +864,7 @@ export type QueryResolvers<ContextType = MyContext, ParentType extends Resolvers
   getAllUserTeams?: Resolver<Array<Maybe<ResolversTypes['UserTeam']>>, ParentType, ContextType>;
   getIssueById?: Resolver<ResolversTypes['Issue'], ParentType, ContextType, RequireFields<QueryGetIssueByIdArgs, 'issueId'>>;
   getProjectById?: Resolver<ResolversTypes['Project'], ParentType, ContextType, RequireFields<QueryGetProjectByIdArgs, 'projectId'>>;
+  getProjectTeamsMembers?: Resolver<Maybe<Array<Maybe<ResolversTypes['Team']>>>, ParentType, ContextType, RequireFields<QueryGetProjectTeamsMembersArgs, 'projectId'>>;
   getRecentProject?: Resolver<Maybe<ResolversTypes['Project']>, ParentType, ContextType>;
   getSprintById?: Resolver<ResolversTypes['Sprint'], ParentType, ContextType, RequireFields<QueryGetSprintByIdArgs, 'id' | 'projectId'>>;
   getTeamById?: Resolver<ResolversTypes['Team'], ParentType, ContextType, RequireFields<QueryGetTeamByIdArgs, 'teamId'>>;
@@ -904,10 +911,10 @@ export type TeamResolvers<ContextType = MyContext, ParentType extends ResolversP
   createdAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   creatorId?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  members?: Resolver<Maybe<Array<Maybe<ResolversTypes['User']>>>, ParentType, ContextType>;
   name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   projects?: Resolver<Maybe<Array<Maybe<ResolversTypes['Project']>>>, ParentType, ContextType>;
   updatedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
+  users?: Resolver<Maybe<Array<Maybe<ResolversTypes['UserTeam']>>>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -948,9 +955,9 @@ export type UserTeamResolvers<ContextType = MyContext, ParentType extends Resolv
   joinedAt?: Resolver<Maybe<ResolversTypes['DateTime']>, ParentType, ContextType>;
   role?: Resolver<Maybe<ResolversTypes['MemberRole']>, ParentType, ContextType>;
   team?: Resolver<Maybe<ResolversTypes['Team']>, ParentType, ContextType>;
-  teamId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  teamId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
-  userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  userId?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 


### PR DESCRIPTION
getProjectTeamsMember resolver return all members that are working on a project. with a projectId all teams with members are fetched from database.
only enrolled users (Admin, contributor and Viewer) can get all members